### PR TITLE
Fixes #1. Fix PHP_VER declarations and checks in bsd.php.mk

### DIFF
--- a/Mk/bsd.php.mk
+++ b/Mk/bsd.php.mk
@@ -279,7 +279,7 @@ _USE_PHP_ALL=	apc bcmath bitset bz2 calendar ctype curl dba dom \
 _USE_PHP_VER5=	${_USE_PHP_ALL} phar sqlite3
 _USE_PHP_VER55=	${_USE_PHP_ALL} phar sqlite3
 _USE_PHP_VER56=	${_USE_PHP_ALL} phar sqlite3
-_USE_PHP_VER7=	${_USE_PHP_ALL} phar sqlite3
+_USE_PHP_VER70=	${_USE_PHP_ALL} phar sqlite3
 
 apc_DEPENDS=	www/pecl-APC
 bcmath_DEPENDS=	math/php${PHP_VER}-bcmath
@@ -303,7 +303,7 @@ iconv_DEPENDS=	converters/php${PHP_VER}-iconv
 igbinary_DEPENDS=	converters/pecl-igbinary
 imap_DEPENDS=	mail/php${PHP_VER}-imap
 interbase_DEPENDS=	databases/php${PHP_VER}-interbase
-.if ${PHP_VER} == 7
+.if ${PHP_VER} == 70
 intl_DEPENDS=	devel/php${PHP_VER}-intl
 .else
 intl_DEPENDS=	devel/pecl-intl
@@ -320,7 +320,7 @@ mysqli_DEPENDS=	databases/php${PHP_VER}-mysqli
 ncurses_DEPENDS=devel/php${PHP_VER}-ncurses
 odbc_DEPENDS=	databases/php${PHP_VER}-odbc
 oci8_DEPENDS=	databases/php${PHP_VER}-oci8
-.if ${PHP_VER} == 55 || ${PHP_VER} == 56 || ${PHP_VER} == 7
+.if ${PHP_VER} == 55 || ${PHP_VER} == 56 || ${PHP_VER} == 70
 opcache_DEPENDS=	www/php${PHP_VER}-opcache
 .else
 opcache_DEPENDS=	www/pecl-zendopcache


### PR DESCRIPTION
Fixes #1. Tested building on Poudriere, not for all extensions, but for most. All of those extensions also work fine after building and installing the packages.
